### PR TITLE
Adjusts to changes in sage-temporary-sdl*

### DIFF
--- a/haskanoid.cabal
+++ b/haskanoid.cabal
@@ -112,7 +112,7 @@ executable haskanoid
                    sage-audio-sdl1,
                    sage-clock-sdl1,
                    sage-sdl1-extra,
-                   sage-temporary-sdl1
+                   sage-render-sdl1
     other-modules: Display
                    ResourceManager
                    ResourceSpecs

--- a/haskanoid.cabal
+++ b/haskanoid.cabal
@@ -128,6 +128,7 @@ executable haskanoid
                    sage-audio-sdl2,
                    sage-clock-sdl2,
                    sage-sdl2-extra,
+                   sage-render-sdl2,
                    sage-temporary-sdl2
     other-modules: Display
                    ResourceManager

--- a/src/Display.hs
+++ b/src/Display.hs
@@ -46,7 +46,7 @@ getRealRenderingCtx :: RenderingCtx -> IO RealRenderingCtx
 #ifdef sdl
 getRealRenderingCtx () = getVideoSurface
 #else
-getRealRenderingCtx = id
+getRealRenderingCtx = return
 #endif
 
 -- * Initialization


### PR DESCRIPTION
sage now has sage-render-sdl1 and sage-render-sdl2.